### PR TITLE
Explicitly use registrator:v5

### DIFF
--- a/part2c/Vagrantfile
+++ b/part2c/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "registrator" do |registrator|
     registrator.vm.provider "docker" do |d|
-      d.image   = "gliderlabs/registrator"
+      d.image   = "gliderlabs/registrator:v5"
       d.volumes = ['/var/run/docker.sock:/tmp/docker.sock']
       d.cmd     = ['consul://192.168.190.85:8500']
     end

--- a/part3/Vagrantfile
+++ b/part3/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "registrator" do |registrator|
     registrator.vm.provider "docker" do |d|
-      d.image   = "gliderlabs/registrator"
+      d.image   = "gliderlabs/registrator:v5"
       d.volumes = ['/var/run/docker.sock:/tmp/docker.sock']
       d.cmd     = ['consul://192.168.190.85:8500']
     end


### PR DESCRIPTION
Using registrator:v6 results in:
telnet redis.service.consul 6379
Trying 172.17.0.31...
telnet: Unable to connect to remote host: Connection refused

Easy fix for now: explicitly use tag v5
